### PR TITLE
Use MiddlewareMixin for pre and post Django 1.10 support.

### DIFF
--- a/src/atris/middleware.py
+++ b/src/atris/middleware.py
@@ -1,7 +1,9 @@
+from django.utils.deprecation import MiddlewareMixin
+
 from atris.models import HistoryLogging
 
 
-class LoggingRequestMiddleware(object):
+class LoggingRequestMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         HistoryLogging.thread.request = request


### PR DESCRIPTION
As per [documentation](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware), `MiddlewareMixin` should be used.