### PR TITLE
Fix false historicalrecords

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 
 setup(
     name='django-atris',
-    version='1.3.4',
+    version='1.4.0',
     description='Django history logging.',
     long_description=(
         'Django history logger that keeps track of changes on a global '

--- a/src/atris/models/helpers.py
+++ b/src/atris/models/helpers.py
@@ -4,8 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import router
 
 
-def get_diff_fields(model, data, previous_data, excluded_fields_names,
-                    check_fake=True):
+def get_diff_fields(model, data, previous_data, excluded_fields_names):
     """
     Returns the fields of `data` for which the values differ in
     `previous_data`. The fields that are given in `excluded_fields_names` are
@@ -18,7 +17,7 @@ def get_diff_fields(model, data, previous_data, excluded_fields_names,
         model._meta.get_field(f).name for f, v in data.items()
         if f not in excluded_fields_names and previous_data.get(f) != v
     ]
-    if check_fake and diff_is_fake(data, previous_data, diff_fields):
+    if diff_is_fake(data, previous_data, diff_fields):
         # Takes into account that in atris < 1.4
         # m2m relation ids were unordered,
         # which often yielded false positives

--- a/src/atris/models/helpers.py
+++ b/src/atris/models/helpers.py
@@ -32,8 +32,7 @@ def diff_is_fake(data, prev_data, diff_fields):
     it means it's a false diff.
     """
     for field_name in diff_fields:
-        value = data[field_name]
-        id_list = re.match(r'^(\d+,\s)+\d+$', value)
+        id_list = re.match(r'^(\d+,\s)+\d+$', data[field_name] or '')
         if not id_list:
             return False
         else:

--- a/src/atris/models/helpers.py
+++ b/src/atris/models/helpers.py
@@ -1,8 +1,11 @@
+import re
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import router
 
 
-def get_diff_fields(model, data, previous_data, excluded_fields_names):
+def get_diff_fields(model, data, previous_data, excluded_fields_names,
+                    check_fake=True):
     """
     Returns the fields of `data` for which the values differ in
     `previous_data`. The fields that are given in `excluded_fields_names` are
@@ -11,9 +14,34 @@ def get_diff_fields(model, data, previous_data, excluded_fields_names):
     """
     if not previous_data:
         return []
-    return [model._meta.get_field(f).name
-            for f, v in data.items()
-            if f not in excluded_fields_names and previous_data.get(f) != v]
+    diff_fields = [
+        model._meta.get_field(f).name for f, v in data.items()
+        if f not in excluded_fields_names and previous_data.get(f) != v
+    ]
+    if check_fake and diff_is_fake(data, previous_data, diff_fields):
+        # Takes into account that in atris < 1.4
+        # m2m relation ids were unordered,
+        # which often yielded false positives
+        return []
+    return diff_fields
+
+
+def diff_is_fake(data, prev_data, diff_fields):
+    """
+    If all the diff_fields have values like '123, 456' vs '456, 123'
+    it means it's a false diff.
+    """
+    for field_name in diff_fields:
+        value = data[field_name]
+        id_list = re.match(r'^(\d+,\s)+\d+$', value)
+        if not id_list:
+            return False
+        else:
+            old_set = set(prev_data[field_name].split(', '))
+            curr_set = set(data[field_name].split(', '))
+            if old_set != curr_set:
+                return False
+    return True
 
 
 def get_instance_field_data(instance):
@@ -34,7 +62,7 @@ def get_instance_field_data(instance):
             value = None
         if field.many_to_many or field.one_to_many:
             ids = from_writable_db(value).values_list('pk', flat=True)
-            data[name] = ', '.join([str(e) for e in ids])
+            data[name] = ', '.join([str(e) for e in ids.order_by('pk')])
         elif field.one_to_one and not field.concrete:
             data[name] = str(value.pk) if value is not None else None
         else:

--- a/tests/tests/functional/history_logging/conftest.py
+++ b/tests/tests/functional/history_logging/conftest.py
@@ -45,3 +45,14 @@ def episode(show, writer):
 @fixture
 def season(show):
     return Season.objects.create(title='1', description='Something', show=show)
+
+
+def history_format_fks(ids):
+    """
+    Sorts a list of ids and converts to the format compatible with
+    atris data
+    :param ids: list of primary keys
+    :return: string of concatenated ids after sort
+    """
+    sorted_ids = sorted([str(u) for u in ids])
+    return ', '.join(sorted_ids)

--- a/tests/tests/functional/history_logging/test_history_for_crud_operations.py
+++ b/tests/tests/functional/history_logging/test_history_for_crud_operations.py
@@ -9,6 +9,7 @@ from django.utils.timezone import now
 from pytest import mark
 
 from tests.models import Poll, Choice, Voter
+from tests.tests.functional.history_logging.conftest import history_format_fks
 
 
 str = unicode if six.PY2 else str  # noqa
@@ -73,10 +74,11 @@ def test_updating_related_fields_recorded_for_model(choice, voter):
     assert choice.history.count() == 2
     updated_poll_and_voters = choice.history.first()
     assert updated_poll_and_voters.history_type == '~'
-    assert set(updated_poll_and_voters.history_diff) == set(['poll', 'voters'])
+    assert set(updated_poll_and_voters.history_diff) == {'poll', 'voters'}
     assert updated_poll_and_voters.data['poll'] == str(new_poll.pk)
-    expected_voters = '{}, {}'.format(another_voter.pk, voter.pk)
-    assert updated_poll_and_voters.data['voters'] == expected_voters
+    assert updated_poll_and_voters.data['voters'] == history_format_fks([
+        voter.pk, another_voter.pk
+    ])
 
 
 @mark.django_db

--- a/tests/tests/functional/history_logging/test_related_fields.py
+++ b/tests/tests/functional/history_logging/test_related_fields.py
@@ -5,6 +5,7 @@ from atris.models import HistoryLogging
 from tests.models import (
     Show, Actor, Writer, Link, Voter, Group, Admin, Season, Episode, Episode2
 )
+from tests.tests.functional.history_logging.conftest import history_format_fks
 
 
 @mark.django_db
@@ -57,14 +58,14 @@ def test_changing_a_foreign_key_value_reflected_on_both_past_and_present_referen
 @mark.django_db
 def test_generic_foreign_keys_backed_by_a_generic_relation_are_recorded(show):
     # arrange
-    show_url_3 = Link.objects.create(
-        name='PBS link',
-        url='http://pbs.org/mercy-street',
-        related_object=show
-    )
     show_url_2 = Link.objects.create(
         name='Amazon link',
         url='http://amazon.com/mercy-street',
+        related_object=show
+    )
+    show_url_3 = Link.objects.create(
+        name='PBS link',
+        url='http://pbs.org/mercy-street',
         related_object=show
     )
     # assert
@@ -72,7 +73,8 @@ def test_generic_foreign_keys_backed_by_a_generic_relation_are_recorded(show):
     assert link_update_notif.related_field_history is not None
     assert link_added.history_type == '~'
     assert link_added.history_diff == ['links']
-    expected_links = '{}, {}'.format(show_url_2.pk, show_url_3.pk)
+    expected_links = history_format_fks([
+        show_url_2.pk, show_url_3.pk])
     assert link_added.data['links'] == expected_links
 
 
@@ -115,7 +117,8 @@ def test_adding_to_many_to_many_relations_recorded_on_both_sides(episode):
     cast_updated = episode.history.first()
     assert cast_updated.history_type == '~'
     assert cast_updated.history_diff == ['cast']
-    assert cast_updated.data['cast'] == '{}, {}'.format(actor3.pk, actor2.pk)
+    assert cast_updated.data['cast'] == history_format_fks([
+        actor3.pk, actor2.pk])
     episode_update_notif, special_added = actor3.history.all()[:2]
     assert episode_update_notif.related_field_history is not None
     assert special_added.history_type == '~'
@@ -281,15 +284,17 @@ def test_history_generated_for_object_through_reverse_m2m_relation_with_untracke
     assert voters_cleared.data['voters'] == ''
     assert voter2_removed.history_type == '~'
     assert voter2_removed.history_diff == ['voters']
-    assert voter2_removed.data['voters'] == '{}, {}'.format(voter1.pk,
-                                                            voter3.pk)
+    assert voter2_removed.data['voters'] == history_format_fks([
+        voter1.pk, voter3.pk
+    ])
     assert voter3_added.history_type == '~'
     assert voter3_added.history_diff == ['voters']
-    assert voter3_added.data['voters'] == '{}, {}, {}'.format(
-        voter1.pk, voter2.pk, voter3.pk)
+    assert voter3_added.data['voters'] == history_format_fks([
+        voter1.pk, voter2.pk, voter3.pk])
     assert voters_set.history_type == '~'
     assert voters_set.history_diff == ['voters']
-    assert voters_set.data['voters'] == '{}, {}'.format(voter1.pk, voter2.pk)
+    assert voters_set.data['voters'] == history_format_fks([
+        voter1.pk, voter2.pk])
     assert group_created.history_type == '+'
 
 
@@ -319,15 +324,16 @@ def test_history_generated_for_object_with_m2m_field_to_untracked_object():  # n
     assert admins_cleared.data['admins'] == ''
     assert admin2_removed.history_type == '~'
     assert admin2_removed.history_diff == ['admins']
-    assert admin2_removed.data['admins'] == '{}, {}'.format(admin1.pk,
-                                                            admin3.pk)
+    assert admin2_removed.data['admins'] == history_format_fks([
+        admin1.pk, admin3.pk])
     assert admin3_added.history_type == '~'
     assert admin3_added.history_diff == ['admins']
-    assert admin3_added.data['admins'] == '{}, {}, {}'.format(
-        admin1.pk, admin2.pk, admin3.pk)
+    assert admin3_added.data['admins'] == history_format_fks([
+        admin1.pk, admin2.pk, admin3.pk])
     assert admins_set.history_type == '~'
     assert admins_set.history_diff == ['admins']
-    assert admins_set.data['admins'] == '{}, {}'.format(admin1.pk, admin2.pk)
+    assert admins_set.data['admins'] == history_format_fks([
+        admin1.pk, admin2.pk])
     assert group_created.history_type == '+'
 
 

--- a/tests/tests/functional/history_logging/test_related_fields.py
+++ b/tests/tests/functional/history_logging/test_related_fields.py
@@ -434,3 +434,17 @@ def test_additional_data_from_initialy_changed_instance_copied_to_history_of_man
     )
     expected = {'where_from': 'Space', 'message': 'We come in peace!'}
     assert group_update_with_episode.additional_data == expected
+
+
+@mark.django_db
+def test_reordering_many_to_many_does_not_generate_record(episode):
+    actor2 = Actor.objects.create(name='Suzanne Bertish')
+    actor3 = Actor.objects.create(name='McKinley Belcher III')
+    episode.cast.add(actor3, actor2)
+    cast_updated = episode.history.first()
+    # re-order m2m
+    cast_updated.data['cast'] = '{}, {}'.format(actor3.id, actor2.id)
+    cast_updated.save()
+    episode.save()
+
+    assert episode.history.count() == 2  # save + 1 update


### PR DESCRIPTION
We start ordering the FK id's when serializing instance data so we won't have false differences when the querysets returns m2m relations in different order.
We also do a check at compare time to see if the diff fields are actually a case of the described bug. This should not be necessary after the ordering but we don't want to trigger new events just because of the ordering.