### PR TITLE
CASH-1125 Fix missing new historical record.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 
 setup(
     name='django-atris',
-    version='1.4.2',
+    version='1.4.3',
     description='Django history logging.',
     long_description=(
         'Django history logger that keeps track of changes on a global '

--- a/src/atris/models/helpers.py
+++ b/src/atris/models/helpers.py
@@ -12,7 +12,7 @@ def get_diff_fields(model, data, previous_data, excluded_fields_names):
     :param model: - the Django model or an instance of that model.
     """
     if not previous_data:
-        return []
+        return None
     diff_fields = [
         model._meta.get_field(f).name for f, v in data.items()
         if f not in excluded_fields_names and previous_data.get(f) != v


### PR DESCRIPTION
Bug: If all history is archived for an object and the object is updated no record is created.
Fix: Change get_diff_fields from helpers.py in order to allow new history objects to be created.