### PR TITLE
CASH-1184 Fix InterestedObjectHistoryGenerator when history_diff is None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 
 setup(
     name='django-atris',
-    version='1.4.3',
+    version='1.4.4',
     description='Django history logging.',
     long_description=(
         'Django history logger that keeps track of changes on a global '

--- a/src/atris/models/history_logging.py
+++ b/src/atris/models/history_logging.py
@@ -413,9 +413,12 @@ class InterestedObjectHistoryGenerator(object):
         self.previous_data = previous_data
 
     def __call__(self):
+        # Make sure the value changed check is made against an empty list in case history_diff is None
+        fields_to_check = self.instance_history.history_diff or []
+
         for field_name in self.interested_fields:
             field_value_changed = (
-                field_name in self.instance_history.history_diff or
+                field_name in fields_to_check or
                 self.instance_history.history_type == HistoricalRecord.DELETE
             )
             get_related_objects = HistoryEnabledRelatedObjectsCollecter(
@@ -424,7 +427,7 @@ class InterestedObjectHistoryGenerator(object):
                 self.previous_data if field_value_changed else None
             )
             interested_objects = get_related_objects()
-            field_changed = field_name in self.instance_history.history_diff
+            field_changed = field_name in fields_to_check
             for interested_object, status in interested_objects.items():
                 # Register any changes to the interested object before the
                 # observed object notification is logged into history.


### PR DESCRIPTION
Small fix for InterestedObjectHistoryGenerator failing when instance_history.history_diff is None with python TypeError - `argument of type 'NoneType' is not iterable`. The fix is consistent with the RelatedFieldHistoryGenerator implementation which was already checking this(line 368).

This error was affecting TVault for update operations which were missing historical records - https://projects.pbs.org/jira/browse/CASH-1184
The error was caused by the last release to this repository(1.4.3) which returns None for history_diff in case there's no existent historical  record for an update operation.

I checked history_diff usage across the entire repository and it seems the None value should not affect any other logic.