### PR TITLE
OCTO-10654 Django 4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ This app requires:
     - for Django > 2.0.0                please use django-atris > 1.2.1
     - for Django >= 3.2 < 4.0           please use django-atris = 2.0.1
     - for Django >= 3.2.19 <= 4.2.6     please use django-atris = 2.0.2
+    - for Django >= 4 < 5               please use django-atris = 2.0.3
 - Postgresql
 - Python:
     - for django-atris < 2.0.0          please use Python >= 2.7 or Python >= 3.4 (after Django 2)
@@ -240,3 +241,7 @@ Changelog
     * Dropped support for Django 2
     * Added support for Django 4 (tested up to 4.2.6)
     * Dropped support for python < 3.8
+
+2.0.3:
+    * Dropped support for Django 3
+    * Extended support beyond 4.2.6 up to less than Django 5 (tested up to 4.2.7)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "Django>=3.2.19,<=4.2.6",
+    "Django>=4,<5",
 ]
-version = "2.0.2"
+version = "2.0.3"
 
 [tool.setuptools]
 zip-safe = false

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.6
+Django==4.2.7
 psycopg2-binary==2.9.9
 pytest==7.4.2
 pytest-cov==4.1.0


### PR DESCRIPTION
Allowing django > 4.2.6
Dropping support for Django 3